### PR TITLE
Potential fix for code scanning alert no. 6: Insecure randomness

### DIFF
--- a/app/[company]/roadmap/page.tsx
+++ b/app/[company]/roadmap/page.tsx
@@ -21,7 +21,12 @@ const getSessionId = () => {
   if (!sessionId) {
     // Use cryptographically secure random values (16 bytes hex)
     const array = new Uint8Array(16)
-    window.crypto.getRandomValues(array)
+    if (window.crypto && typeof window.crypto.getRandomValues === 'function') {
+      window.crypto.getRandomValues(array)
+    } else {
+      // Fallback: This should rarely happen in modern browsers
+      throw new Error('Crypto API not available')
+    }
     sessionId = Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
     localStorage.setItem('sugary_session_id', sessionId)
   }

--- a/app/[company]/roadmap/page.tsx
+++ b/app/[company]/roadmap/page.tsx
@@ -19,7 +19,10 @@ const PUBLIC_COLUMNS = [
 const getSessionId = () => {
   let sessionId = localStorage.getItem('sugary_session_id')
   if (!sessionId) {
-    sessionId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+    // Use cryptographically secure random values (16 bytes hex)
+    const array = new Uint8Array(16)
+    window.crypto.getRandomValues(array)
+    sessionId = Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
     localStorage.setItem('sugary_session_id', sessionId)
   }
   return sessionId


### PR DESCRIPTION
Potential fix for [https://github.com/erichasinternet/sugary/security/code-scanning/6](https://github.com/erichasinternet/sugary/security/code-scanning/6)

To fix the insecure randomness, replace usage of `Math.random()` in `getSessionId()` with a browser-provided cryptographically secure random generator. For browsers, `window.crypto.getRandomValues()` is the standard: we can generate a random 16- or 32-byte array, convert it to a hex string or base64, and use that as the session ID. This should be done in the same spot on line 22. No changes to the structure or usage of the session ID are required, only how it is generated. Add detection/fallback logic in case `window.crypto` is unavailable, but typically in modern browsers `window.crypto` is present.

We do not need a new external dependency; just use the native `window.crypto.getRandomValues`. To ensure uniqueness and randomness, generate (for example) 16 bytes and encode as hex.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
